### PR TITLE
Fix json object ingest for python usage

### DIFF
--- a/verify_signature.py
+++ b/verify_signature.py
@@ -9,11 +9,16 @@ def verify_signature(secret, compact_json_payload, signature):
     return hmac.compare_digest(signature, computed_hash)
 
 
-payload = {
-    'monday': '75F',
-    'tuesday': '80F'
-}
+json_string = '''{
+    "monday": "75F",
+    "tuesday": "80F"
+}'''
+
 # Warning! JSON must be compact. Pretty JSON with spaces will not work.
+# First convert the json string to a Python object
+payload = json.loads(json_string)
+
+# Then from a Python object to a compact json string
 compact_json_payload = json.dumps(payload, separators=(',', ':'))
 
 payload_signature = 'b7412f05e981a473b5ecbdb5393afaea02a679db6d7c8e56803512ec4ba98151'


### PR DESCRIPTION
Json objects contains fields like `true`, `false` or `null` that are not recognized by python which should be `True`, `False` or `none`.

This MR converts the JSON object into a python readable object first